### PR TITLE
Pass wrapped function name to mobx action

### DIFF
--- a/src/task.js
+++ b/src/task.js
@@ -9,6 +9,7 @@ const { proxyGetters, promiseTry } = require('./utils')
  */
 function createTask(fn, opts) {
   opts = {
+    wrappedFnName: fn.name ? fn.name : 'unnamed function',
     swallow: false,
     state: 'pending',
     args: [],
@@ -118,7 +119,7 @@ function setupTask(fn, taskState, taskStateSchemaKeys, opts) {
      * Assigns the given properties to the task.
      * E.g. task.setState({ state: 'resolved', result: 1337 })
      */
-    setState: action(opts => {
+    setState: action(opts.wrappedFnName, opts => {
       Object.assign(taskState, opts)
       return fn
     }),

--- a/src/task.js
+++ b/src/task.js
@@ -9,7 +9,6 @@ const { proxyGetters, promiseTry } = require('./utils')
  */
 function createTask(fn, opts) {
   opts = {
-    wrappedFnName: fn.name ? fn.name : 'unnamed function',
     swallow: false,
     state: 'pending',
     args: [],
@@ -119,7 +118,7 @@ function setupTask(fn, taskState, taskStateSchemaKeys, opts) {
      * Assigns the given properties to the task.
      * E.g. task.setState({ state: 'resolved', result: 1337 })
      */
-    setState: action(opts.wrappedFnName, opts => {
+    setState: action('setState', opts => {
       Object.assign(taskState, opts)
       return fn
     }),


### PR DESCRIPTION
This allows for simpler debugging when using mobx-logger. Without this patch mobx-task actions appear in the log as: "ACTION task.<unnamed action>". This allows the logged action to appear similar to a natively logged mobx action.