### PR TITLE
fix: Fix sourcemaps content

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
     "module": "commonjs",
     "moduleResolution": "node",
     "sourceMap": true,
+    "inlineSources": true,
     "declaration": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
Source TS files are not bundled with the package while the generated sourcemaps [don't contain](https://unpkg.com/mobx-task@2.0.0/lib/index.js.map) `sourcesContent`. Either one has to be fixed in order for sourcemaps to be valid.
This fix tells TS compiler to emit `sourcesContent` similar to [`mobx-react-lite`](https://unpkg.com/mobx-react-lite@2.0.7/dist/mobxreactlite.cjs.development.js.map) .